### PR TITLE
Rewrite Istio wait commands

### DIFF
--- a/stable/application-component/Chart.yaml
+++ b/stable/application-component/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.10
+version: 1.2.11
 
 # This field should not be changed/fiddled. For Application version we use Values.version field
 appVersion: "0.0.0"

--- a/stable/application-component/templates/deployment.yaml
+++ b/stable/application-component/templates/deployment.yaml
@@ -151,7 +151,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - {{ print .Values.mesh.lifecycle.shutdownWaitCommand | quote }}
+                  - {{ .Values.mesh.lifecycle.shutdownWaitCommand | quote }}
           {{ else if or (eq .Values.availability "critical") (eq .Values.availability "high") }}
           {{- /* When availability important - wait 15 seconds before sending TERM signal. This allow upstream services to account for pod changes */}}
           lifecycle:

--- a/stable/application-component/templates/deployment.yaml
+++ b/stable/application-component/templates/deployment.yaml
@@ -90,8 +90,8 @@ spec:
           command:
             - "sh"
             - "-c"
-            {{- if and .Values.global.mesh.enabled .Values.global.mesh.injectionEnabled }}
-            - {{ print .Values.waitForIstio .Values.command | quote }}
+            {{- if and .Values.global.mesh.enabled .Values.global.mesh.injectionEnabled .Values.mesh.lifecycle.enabled }}
+            - {{ print .Values.mesh.lifecycle.startupWaitCommand .Values.command | quote }}
             {{- else }}
             - {{ .Values.command | quote }}
             {{- end }}
@@ -143,6 +143,15 @@ spec:
           {{- if .Values.deployment.lifecycle }}
           lifecycle:
             {{ toYaml .Values.deployment.lifecycle | nindent 12 }}
+          {{- /* Wait for application exit, then send quitquit to the istio */}}
+          {{ else if and .Values.global.mesh.enabled .Values.global.mesh.injectionEnabled .Values.mesh.lifecycle.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - {{ print .Values.mesh.lifecycle.shutdownWaitCommand | quote }}
           {{ else if or (eq .Values.availability "critical") (eq .Values.availability "high") }}
           {{- /* When availability important - wait 15 seconds before sending TERM signal. This allow upstream services to account for pod changes */}}
           lifecycle:

--- a/stable/application-component/tests/golden/components/deployment-advanced.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-advanced.golden.yaml
@@ -59,7 +59,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/deployment-advanced.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-advanced.golden.yaml
@@ -53,6 +53,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/deployment-runtime.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-runtime.golden.yaml
@@ -77,7 +77,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             exec:

--- a/stable/application-component/tests/golden/components/deployment-runtime.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-runtime.golden.yaml
@@ -71,6 +71,14 @@ spec:
               readOnly: true
             - mountPath: /cache
               name: cache-vol
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             exec:
               command: [/app/ops/scripts/check_sidekiq.sh]

--- a/stable/application-component/tests/golden/components/deployment-scheduling.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-scheduling.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 400m

--- a/stable/application-component/tests/golden/components/deployment-scheduling.golden.yaml
+++ b/stable/application-component/tests/golden/components/deployment-scheduling.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/hpa.golden.yaml
+++ b/stable/application-component/tests/golden/components/hpa.golden.yaml
@@ -157,7 +157,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/hpa.golden.yaml
+++ b/stable/application-component/tests/golden/components/hpa.golden.yaml
@@ -151,6 +151,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/image-custom.golden.yaml
+++ b/stable/application-component/tests/golden/components/image-custom.golden.yaml
@@ -62,7 +62,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/image-custom.golden.yaml
+++ b/stable/application-component/tests/golden/components/image-custom.golden.yaml
@@ -56,6 +56,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/image-global.golden.yaml
+++ b/stable/application-component/tests/golden/components/image-global.golden.yaml
@@ -62,7 +62,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/image-global.golden.yaml
+++ b/stable/application-component/tests/golden/components/image-global.golden.yaml
@@ -56,6 +56,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/monitoring.golden.yaml
+++ b/stable/application-component/tests/golden/components/monitoring.golden.yaml
@@ -114,7 +114,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/monitoring.golden.yaml
+++ b/stable/application-component/tests/golden/components/monitoring.golden.yaml
@@ -108,6 +108,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/service.golden.yaml
+++ b/stable/application-component/tests/golden/components/service.golden.yaml
@@ -62,7 +62,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/service.golden.yaml
+++ b/stable/application-component/tests/golden/components/service.golden.yaml
@@ -56,6 +56,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/components/serviceaccount.golden.yaml
+++ b/stable/application-component/tests/golden/components/serviceaccount.golden.yaml
@@ -77,7 +77,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/components/serviceaccount.golden.yaml
+++ b/stable/application-component/tests/golden/components/serviceaccount.golden.yaml
@@ -71,6 +71,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/defaults/defaults.golden.yaml
+++ b/stable/application-component/tests/golden/defaults/defaults.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/defaults/defaults.golden.yaml
+++ b/stable/application-component/tests/golden/defaults/defaults.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 1200m

--- a/stable/application-component/tests/golden/deployment-schemes/critical-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-mixed.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/critical-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-mixed.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/critical-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-on_demand.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/critical-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-on_demand.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/critical-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-spot.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/critical-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/critical-spot.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/high-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-mixed.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/high-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-mixed.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/high-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-on_demand.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/high-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-on_demand.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/high-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-spot.golden.yaml
@@ -57,7 +57,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/high-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/high-spot.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-mixed.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 600m

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-mixed.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-on_demand.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 600m

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-on_demand.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-spot.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           resources:
             limits:
               cpu: 600m

--- a/stable/application-component/tests/golden/deployment-schemes/irrelevant-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/irrelevant-spot.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           resources:
             limits:

--- a/stable/application-component/tests/golden/deployment-schemes/normal-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-mixed.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/normal-mixed.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-mixed.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/normal-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-on_demand.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/normal-on_demand.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-on_demand.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/deployment-schemes/normal-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-spot.golden.yaml
@@ -54,6 +54,14 @@ spec:
             - name: dynamic-sa-token
               mountPath: /var/run/secrets/tokens
               readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/tests/golden/deployment-schemes/normal-spot.golden.yaml
+++ b/stable/application-component/tests/golden/deployment-schemes/normal-spot.golden.yaml
@@ -60,7 +60,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/standard-configurations/regular-webserver.golden.yaml
+++ b/stable/application-component/tests/golden/standard-configurations/regular-webserver.golden.yaml
@@ -149,7 +149,7 @@ spec:
                 command:
                   - "sh"
                   - "-c"
-                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
           
           startupProbe:
             httpGet:

--- a/stable/application-component/tests/golden/standard-configurations/regular-webserver.golden.yaml
+++ b/stable/application-component/tests/golden/standard-configurations/regular-webserver.golden.yaml
@@ -146,7 +146,11 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "sleep 15"]
+                command:
+                  - "sh"
+                  - "-c"
+                  - "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+          
           startupProbe:
             httpGet:
               path: /healthz/webserver

--- a/stable/application-component/values.yaml
+++ b/stable/application-component/values.yaml
@@ -326,7 +326,7 @@ mesh:
     # Wait for Istio service to be available, before running container command
     startupWaitCommand: "until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';"
     # preStopHook to execute on shutdown
-    shutdownWaitCommand: "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+    shutdownWaitCommand: "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
 
 
 # default contain default values for various resources

--- a/stable/application-component/values.yaml
+++ b/stable/application-component/values.yaml
@@ -74,9 +74,6 @@ applicationImage:
   # Overrides the image tag whose default is the Values.version.
   tag: ""
 
-# Wait for Istio service to be available, then run the specified command
-waitForIstio: "until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';"
-
 # Deployment configurations
 deployment:
   # Number of pods to run. Ignored when autoscaling enabled
@@ -321,6 +318,16 @@ serviceAccount:
   name: ""
   # Additional Annotations to add to the service account when creating
   annotations: {}
+
+mesh:
+  # Configuration to orchestrate correct start/stop of components in a mesh
+  lifecycle:
+    enabled: true
+    # Wait for Istio service to be available, before running container command
+    startupWaitCommand: "until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';"
+    # preStopHook to execute on shutdown
+    shutdownWaitCommand: "echo 'Waiting for Application exit'; kill 1; wait 1; echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit"
+
 
 # default contain default values for various resources
 defaults:

--- a/stable/application-migration/Chart.yaml
+++ b/stable/application-migration/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.6
+version: 1.2.11
 
 # This field should not be changed/fiddled. For Application version we use Values.version field
 appVersion: "0.0.0"

--- a/stable/application-migration/templates/job.yaml
+++ b/stable/application-migration/templates/job.yaml
@@ -80,13 +80,13 @@ spec:
           command:
             - "sh"
             - "-c"
-            {{- if and .Values.global.mesh.enabled .Values.global.mesh.injectionEnabled }}
+            {{- if and .Values.global.mesh.enabled .Values.global.mesh.injectionEnabled .Values.mesh.lifecycle.enabled }}
             - |
-              until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done;
-              echo 'Istio ready. Running the command...';
+              {{ .Values.mesh.lifecycle.startupWaitCommand }}
               {{ .Values.command }};
               x=$(echo $?);
-              wget --quiet --post-data="Please exit" -o /dev/null http://localhost:15020/quitquitquit && exit $x
+              {{ .Values.mesh.lifecycle.shutdownWaitCommand }}
+              exit $x
             {{- else }}
             - {{ .Values.command | quote }}
             {{- end }}

--- a/stable/application-migration/tests/golden/components/job-runtime.golden.yaml
+++ b/stable/application-migration/tests/golden/components/job-runtime.golden.yaml
@@ -46,11 +46,11 @@ spec:
             - "sh"
             - "-c"
             - |
-              until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done;
-              echo 'Istio ready. Running the command...';
+              until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';
               rails db:migrate;
               x=$(echo $?);
-              wget --quiet --post-data="Please exit" -o /dev/null http://localhost:15020/quitquitquit && exit $x
+              echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;
+              exit $x
           imagePullPolicy: IfNotPresent
           env:
             - name: MY_APP

--- a/stable/application-migration/tests/golden/standard-configurations/regular-migration.golden.yaml
+++ b/stable/application-migration/tests/golden/standard-configurations/regular-migration.golden.yaml
@@ -63,11 +63,11 @@ spec:
             - "sh"
             - "-c"
             - |
-              until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done;
-              echo 'Istio ready. Running the command...';
+              until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';
               rails db:setup db:migrate;
               x=$(echo $?);
-              wget --quiet --post-data="Please exit" -o /dev/null http://localhost:15020/quitquitquit && exit $x
+              echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;
+              exit $x
           imagePullPolicy: IfNotPresent
           env:
             - name: DD_AGENT_HOST

--- a/stable/application-migration/values.yaml
+++ b/stable/application-migration/values.yaml
@@ -116,6 +116,15 @@ serviceAccount:
   # Additional Annotations to add to the service account when creating
   annotations: {}
 
+mesh:
+  # Configuration to orchestrate correct start/stop of components in a mesh
+  lifecycle:
+    enabled: true
+    # Wait for Istio service to be available, before running container command
+    startupWaitCommand: "until wget --quiet --spider -o /dev/null http://localhost:15020/healthz/ready; do echo 'Waiting for Istio...'; sleep 1; done; echo 'Istio ready. Running the command...';"
+    # preStopHook to execute on shutdown
+    shutdownWaitCommand: "echo 'Application finished. Telling Istio to exit'; wget -quiet --post-data 'exit' -o /dev/null http://localhost:15020/quitquitquit;"
+
 defaults:
   # Default DNS configuration for application deployment. Set ndots option to 1
   dnsConfig:


### PR DESCRIPTION
This change started from the fact that I need to switch to curl in new app, but migration container does not allow customization. After fiddling a bit - decided to improve existing solution as well:

- Added shutdown wait command for application component
- After application has finished - telling istio to exit and not wait
- Added same configuration for migration component