### PR TITLE
DOPS-1577: DestinationRule fixes

### DIFF
--- a/stable/application-mesh/Chart.yaml
+++ b/stable/application-mesh/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.6
+version: 0.4.7
 
 # This field should not be changed/fiddled. For Application version we use Values.version field
 appVersion: "0.0.0"

--- a/stable/application-mesh/templates/destination-rule.yaml
+++ b/stable/application-mesh/templates/destination-rule.yaml
@@ -1,5 +1,10 @@
 {{- if .Values.global.mesh.enabled }}
+{{- $destDefaults := $.Values.defaults.destination }}
 {{- range $_, $destination := .Values.destinations }}
+{{- $tcp := merge (dict) ($destination.connectionPool | default dict) ($destDefaults.connectionPool | default dict) }}
+{{- $http := merge (dict) ($destination.http | default dict) ($destDefaults.http | default dict) }}
+{{- $outlier := merge (dict) ($destination.outlierDetection | default dict) ($destDefaults.outlierDetection | default dict) }}
+{{- $lb := default (default "LEAST_REQUEST" $destDefaults.loadBalancer) $destination.loadBalancer }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
@@ -11,8 +16,21 @@ metadata:
 spec:
   host: {{ include "application-mesh.service-host" (merge (dict "component" $destination.component) $) }}
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: {{ $tcp.maxConnections }}
+        connectTimeout: {{ $tcp.connectionTimeout }}
+      http:
+        http1MaxPendingRequests: {{ $http.http1MaxPendingRequests }}
+        maxRequestsPerConnection: {{ $http.maxRequestsPerConnection }}
+        idleTimeout: {{ $http.idleTimeout }}
+    outlierDetection:
+      consecutive5xxErrors: {{ $outlier.consecutive5xxErrors }}
+      interval: {{ $outlier.interval }}
+      baseEjectionTime: {{ $outlier.baseEjectionTime }}
+      maxEjectionPercent: {{ $outlier.maxEjectionPercent }}
     loadBalancer:
-      simple: LEAST_REQUEST
+      simple: {{ $lb }}
   subsets:
     - name: all-versions # Route traffic to all pods regardless of the deployed version. Current deployment model.
       labels:

--- a/stable/application-mesh/tests/golden/components/destination-rule.golden.yaml
+++ b/stable/application-mesh/tests/golden/components/destination-rule.golden.yaml
@@ -10,6 +10,19 @@ metadata:
 spec:
   host: leads-broker-backend.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:

--- a/stable/application-mesh/tests/golden/defaults/defaults.golden.yaml
+++ b/stable/application-mesh/tests/golden/defaults/defaults.golden.yaml
@@ -10,6 +10,19 @@ metadata:
 spec:
   host: leads-broker-webserver.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:

--- a/stable/application-mesh/tests/golden/features/no-trace-proxy.golden.yaml
+++ b/stable/application-mesh/tests/golden/features/no-trace-proxy.golden.yaml
@@ -10,6 +10,19 @@ metadata:
 spec:
   host: leads-broker-webserver.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:

--- a/stable/application-mesh/tests/golden/standard-configurations/single-webserver.golden.yaml
+++ b/stable/application-mesh/tests/golden/standard-configurations/single-webserver.golden.yaml
@@ -10,6 +10,19 @@ metadata:
 spec:
   host: leads-broker-webserver.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:

--- a/stable/application-mesh/tests/golden/standard-configurations/webserver-and-websockets.golden.yaml
+++ b/stable/application-mesh/tests/golden/standard-configurations/webserver-and-websockets.golden.yaml
@@ -10,6 +10,19 @@ metadata:
 spec:
   host: leads-broker-webserver.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:
@@ -32,6 +45,19 @@ metadata:
 spec:
   host: leads-broker-websockets.app-component-test00000.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 200
+        connectTimeout: 5s
+      http:
+        http1MaxPendingRequests: 1024
+        maxRequestsPerConnection: 1000
+        idleTimeout: 60s
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     loadBalancer:
       simple: LEAST_REQUEST
   subsets:

--- a/stable/application-mesh/values.yaml
+++ b/stable/application-mesh/values.yaml
@@ -97,15 +97,29 @@ defaults:
     deny_locations: []
   # Default destination configurations
   destination:
-    # Configurations for tcp connection pool
-    # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings
+    # TCP connection pool settings
+    # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-TCPSettings
     connectionPool:
-      # maxConnections - Maximum number of connections that can be open from source pod to this destination
-      # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-TCPSettings
+      # Maximum number of connections that can be open from source pod to this destination
       maxConnections: 200
-      # connectionTimeout - How long should we wait to establish connection
-      # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-TCPSettings
+      # How long Envoy waits to establish a TCP connection
       connectionTimeout: 5s
+    # HTTP connection pool settings
+    # https://istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings-HTTPSettings
+    # idleTimeout caps keep-alive lifetime on the upstream side; keep below the longest
+    # callee pod lifetime so caller pools rotate connections naturally and don't accumulate
+    # entries pointing at terminated pods.
+    http:
+      http1MaxPendingRequests: 1024
+      maxRequestsPerConnection: 1000
+      idleTimeout: 60s
+    # Outlier ejection: temporarily remove an upstream endpoint after consecutive 5xx
+    # https://istio.io/latest/docs/reference/config/networking/destination-rule/#OutlierDetection
+    outlierDetection:
+      consecutive5xxErrors: 5
+      interval: 10s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 50
     # loadBalancer - what load balance algorithm to use (LEAST_REQUEST, ROUND_ROBIN, RANDOM)
     # https://istio.io/latest/docs/reference/config/networking/destination-rule/#LoadBalancerSettings-SimpleLB
     loadBalancer: LEAST_REQUEST


### PR DESCRIPTION
application-mesh: render connectionPool + outlierDetection on DestintionRule

The DestinationRule template was silently dropping connectionPool and connectionTimeout values from values.yaml — the rendered manifest only contained loadBalancer + subsets. As a result every Envoy upstream cluster ran with untuned defaults: HTTP keep-alive idle ~1h, no outlier ejection, no per-connection request cap. Combined with Palantir's net_http_persistent 300s idle, this kept stale connections in caller pools well past callee pod terminations, surfacing as "upstream connect error ... Connection refused" for in-mesh callers across the fleet.

This change makes the template actually use the values:
  - TCP: maxConnections / connectTimeout (existing keys, now wired up)
  - HTTP: idleTimeout=60s, maxRequestsPerConnection=1000, http1MaxPendingRequests=1024 (new defaults)
  - outlierDetection: 5 consecutive 5xx -> 30s ejection, 50% max (new)

Per-destination overrides via destinations[].connectionPool / .http / .outlierDetection continue to work; existing user values remain backward-compatible via merge against defaults.destination.

Chart bumped to 0.4.7. Goldens regenerated.